### PR TITLE
Added automatic generation of SECRET_KEY setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 /*/settings/local.py
+/*/settings/secret.py
 /*/static/
 /*/media/
 /dev.db

--- a/skeletor/settings/base.py
+++ b/skeletor/settings/base.py
@@ -74,11 +74,19 @@ STATICFILES_FINDERS = (
 #    'django.contrib.staticfiles.finders.DefaultStorageFinder',
 )
 
-# Make this unique, and don't share it with anybody.
-SECRET_KEY = ''
-if not SECRET_KEY:
-    from logging import warn
-    warn('Please set a unique SECRET_KEY in ' + __file__)
+# Import the SECRET_KEY from secret.py
+try:
+    from secret import *
+except ImportError:
+    # If the file doesn't exist, generate a random key
+    from django.utils.crypto import get_random_string
+    secret_chars = 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'
+    secret_str = get_random_string(50, secret_chars)
+
+    # Save the key setting to secret.py
+    secret_path = os.path.join(ABS_PATH('settings'), 'secret.py')
+    with open(secret_path, 'w') as secret_file:
+        secret_file.write("SECRET_KEY = '" + secret_str + "'\n")
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (

--- a/skeletor/settings/base.py
+++ b/skeletor/settings/base.py
@@ -79,15 +79,10 @@ def ensure_secret_key_file():
     with a random generated SECRET_KEY setting."""
     secret_path = os.path.join(ABS_PATH('settings'), 'secret.py')
     if not os.path.exists(secret_path):
-        secret_key = gen_secret_key()
+        from django.utils.crypto import get_random_string
+        secret_key = get_random_string(50, 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)')
         with open(secret_path, 'w') as f:
             f.write("SECRET_KEY = " + repr(secret_key) + "\n")
-
-def gen_secret_key(length=50):
-    """Generates a random secret key of given length."""
-    from django.utils.crypto import get_random_string
-    chars = 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'
-    return get_random_string(length, chars)
 
 # Import the secret key
 ensure_secret_key_file()

--- a/skeletor/settings/base.py
+++ b/skeletor/settings/base.py
@@ -74,19 +74,24 @@ STATICFILES_FINDERS = (
 #    'django.contrib.staticfiles.finders.DefaultStorageFinder',
 )
 
-# Import the SECRET_KEY from secret.py
-try:
-    from secret import *
-except ImportError:
-    # If the file doesn't exist, generate a random key
-    from django.utils.crypto import get_random_string
-    secret_chars = 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'
-    secret_str = get_random_string(50, secret_chars)
-
-    # Save the key setting to secret.py
+def ensure_secret_key_file():
+    """Checks that secret.py exists in settings dir. If not, creates one
+    with a random generated SECRET_KEY setting."""
     secret_path = os.path.join(ABS_PATH('settings'), 'secret.py')
-    with open(secret_path, 'w') as secret_file:
-        secret_file.write("SECRET_KEY = '" + secret_str + "'\n")
+    if not os.path.exists(secret_path):
+        secret_key = gen_secret_key()
+        with open(secret_path, 'w') as f:
+            f.write("SECRET_KEY = " + repr(secret_key) + "\n")
+
+def gen_secret_key(length=50):
+    """Generates a random secret key of given length."""
+    from django.utils.crypto import get_random_string
+    chars = 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'
+    return get_random_string(length, chars)
+
+# Import the secret key
+ensure_secret_key_file()
+from secret import SECRET_KEY
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (


### PR DESCRIPTION
The first time settings are loaded, the secret key is automatically
generated and saved to settings/secret.py, which is added to .gitignore.
This way the secret key is kept out of base settings which are commited
into the repository.

Uses generation algorithm used by django startproject command.
