### PR TITLE
fixed: deprecation warning

### DIFF
--- a/skeletor/urls.py
+++ b/skeletor/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, include, url
+from django.conf.urls import patterns, include, url
 
 from django.contrib import admin
 admin.autodiscover()


### PR DESCRIPTION
in 1.5 django.conf.urls.defaults is deprecated, since dj-skeletor 
requires 1.5, this is the right way to do it.
