### PR TITLE
fix sqlite dj_database_url syntax

### DIFF
--- a/project/settings/dev.py
+++ b/project/settings/dev.py
@@ -6,7 +6,7 @@ TEMPLATE_DEBUG = (ENV_SETTING('TEMPLATE_DEBUG', 'true') == 'true')
 COMPRESS_ENABLED = (ENV_SETTING('COMPRESS_ENABLED', 'true') == 'true')
 
 DATABASES = {'default': dj_database_url.config(
-    default='sqlite://' + ROOT_DIR + '/dev.db')}
+    default='sqlite:////' + ROOT_DIR + '/dev.db')}
 
 EMAIL_BACKEND = ENV_SETTING('EMAIL_BACKEND',
     'django.core.mail.backends.console.EmailBackend')


### PR DESCRIPTION
If only two slashes "sqlite://" are used we get an OperationalError from dj_database_url. The correct syntax is sqlite://// (4 slashes).
